### PR TITLE
Update template.css

### DIFF
--- a/innout/public/assets/css/template.css
+++ b/innout/public/assets/css/template.css
@@ -171,7 +171,7 @@ aside.sidebar .sidebar-widget .info {
 }
 
 .division {
-    widows: 80%;
+    width: 80%;
     border: solid 1px #EEE;
 }
 


### PR DESCRIPTION
Adicionando mudança em um pequeno erro na aula de criação de widget, na classe de divisão criada para separar as duas widgets o professor digitou widows ao inves de width, sendo assim não aplicou o espaçamento desejado.